### PR TITLE
add options for signature text to appear

### DIFF
--- a/lib/src/main/java/BatchPDFSign/lib/BatchPDFSign.java
+++ b/lib/src/main/java/BatchPDFSign/lib/BatchPDFSign.java
@@ -3,6 +3,7 @@ package BatchPDFSign.lib;
 import com.itextpdf.kernel.pdf.PdfReader;
 import com.itextpdf.kernel.pdf.StampingProperties;
 import com.itextpdf.signatures.*;
+import com.itextpdf.kernel.geom.Rectangle;
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -59,7 +60,7 @@ public class BatchPDFSign {
 	 * @throws IOException A File couldn't be opened.
 	 * @throws GeneralSecurityException Some permissions aren't right.
 	 */
-	public void signFile() throws IOException, GeneralSecurityException {
+	public void signFile(int page, float rx, float ry, float rw, float rh, float fs, String signtext) throws IOException, GeneralSecurityException {
 
 		// Check PDF input file
 		if (!inputFile.exists() || inputFile.isDirectory()) {
@@ -70,6 +71,15 @@ public class BatchPDFSign {
 		ITSAClient tsaClient = new TSAClientBouncyCastle("https://freetsa.org/tsr");
 		StampingProperties properties = new StampingProperties().preserveEncryption();
 		PdfSigner signer = new PdfSigner(reader, new FileOutputStream(pdfOutputFileName), properties);
+		if (page > 0) {
+			PdfSignatureAppearance appearance = signer.getSignatureAppearance();
+			appearance.setPageNumber(page);
+			appearance.setPageRect(new Rectangle(rx, ry, rw, rh));
+			appearance.setLayer2FontSize(fs);
+			if (signtext != null) {
+				appearance.setLayer2Text(signtext);
+			}
+		}
 		IExternalDigest digest = new BouncyCastleDigest();
 		BouncyCastleProvider provider = new BouncyCastleProvider();
 		Security.addProvider(provider);
@@ -85,6 +95,9 @@ public class BatchPDFSign {
 				throw new IOException("File: " + this.inputFile + " couldn't be deleted");
 			}
 		}
+	}
+	public void signFile() throws IOException, GeneralSecurityException {
+		this.signFile(0, 0, 0, 0, 0, 10, "");
 	}
 
 	/**

--- a/portable/src/main/java/BatchPDFSign/portable/Main.java
+++ b/portable/src/main/java/BatchPDFSign/portable/Main.java
@@ -33,6 +33,34 @@ public class Main {
         output.setRequired(false);
         options.addOption(output);
 
+        Option pageOpt = new Option("", "page", true, "page of signature rectangle; needs to be specified to output signature rectangle");
+        output.setRequired(false);
+        options.addOption(pageOpt);
+
+        Option rectPosXOpt = new Option("", "rx", true, "x position of signature rectangle");
+        output.setRequired(false);
+        options.addOption(rectPosXOpt);
+
+        Option rectPosYOpt = new Option("", "ry", true, "y position of signature rectangle");
+        output.setRequired(false);
+        options.addOption(rectPosYOpt);
+
+        Option rectWidthOpt = new Option("", "rw", true, "width of signature rectangle");
+        output.setRequired(false);
+        options.addOption(rectWidthOpt);
+
+        Option rectHeightOpt = new Option("", "rh", true, "height of signature rectangle");
+        output.setRequired(false);
+        options.addOption(rectHeightOpt);
+
+        Option fontsizeOpt = new Option("", "fs", true, "height of signature rectangle");
+        output.setRequired(false);
+        options.addOption(fontsizeOpt);
+
+        Option signTextOpt = new Option("", "signtext", true, "signature text");
+        output.setRequired(false);
+        options.addOption(signTextOpt);
+
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine cmd;
@@ -45,7 +73,29 @@ public class Main {
             String passwordString = cmd.getOptionValue("password");
             BatchPDFSign batchPDFSign;
             batchPDFSign = new BatchPDFSign(keyFilePath, passwordString, inputFilePath, outputFilePath);
-            batchPDFSign.signFile();
+            if (cmd.hasOption("page")) {
+                if (!cmd.hasOption("rx") || !cmd.hasOption("ry") ||
+                    !cmd.hasOption("rw") || !cmd.hasOption("rh")) {
+                    System.out.println("If a page is specified, all of the options --rx --ry --rw and --rh also need to be specified.");
+                    System.exit(1);
+                }
+                Integer page = Integer.parseInt(cmd.getOptionValue("page"));
+                Float rectPosX   = Float.parseFloat(cmd.getOptionValue("rx"));
+                Float rectPosY   = Float.parseFloat(cmd.getOptionValue("ry"));
+                Float rectWidth  = Float.parseFloat(cmd.getOptionValue("rw"));
+                Float rectHeight = Float.parseFloat(cmd.getOptionValue("rh"));
+                Float fontSize = 12.f;
+                if (cmd.hasOption("fs")) {
+                    fontSize = Float.parseFloat(cmd.getOptionValue("fs"));
+                }
+                String signText = null;
+                if (cmd.hasOption("signtext")) {
+                    signText  = cmd.getOptionValue("signtext");
+                }
+                batchPDFSign.signFile(page, rectPosX, rectPosY, rectWidth, rectHeight, fontSize, signText);
+            } else {
+                batchPDFSign.signFile();
+            }
         } catch (GeneralSecurityException | IOException | ParseException e) {
             System.out.println(e.getMessage());
             formatter.printHelp("BatchPDFSignPortable", options);


### PR DESCRIPTION
Add new options

  --page, --rx, --ry, --rw, --rh, --fs, and --signtext

to configure the appaerance of the signature object within the pdf.

This can be nice, as it makes it easier for someone used to a GUI to click
that box to open a dialog to check the signature.