### PR TITLE
read password from stdin if '-p -' was specified

### DIFF
--- a/portable/src/main/java/BatchPDFSign/portable/Main.java
+++ b/portable/src/main/java/BatchPDFSign/portable/Main.java
@@ -5,6 +5,7 @@ import org.apache.commons.cli.*;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Scanner;
 
 /**
  * This method is called when the jar is executed. It shows the help if parameters weren't given correctly.
@@ -43,6 +44,12 @@ public class Main {
             String outputFilePath = cmd.getOptionValue("output");
             String keyFilePath = cmd.getOptionValue("key");
             String passwordString = cmd.getOptionValue("password");
+            if (passwordString.equals("-")) {
+                Scanner scanner = new Scanner(System.in);
+                if (scanner.hasNextLine()) {
+                    passwordString = scanner.nextLine();
+                }
+            }
             BatchPDFSign batchPDFSign;
             batchPDFSign = new BatchPDFSign(keyFilePath, passwordString, inputFilePath, outputFilePath);
             batchPDFSign.signFile();


### PR DESCRIPTION
Passing the password on the command line in usually frowned upon, as the command can be visible by other users on the same system. This patch checks if a single minus sign '-' was specified as password and if so, reads the password from stdin instead.